### PR TITLE
move clang-tidy and clang-format config to files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 2
+---
+Language: Cpp

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,7 @@
+---
+Checks:          'clang-analyzer-*,clang-diagnostic-*,readability-*,bugprone-*,misc-*'
+WarningsAsErrors: true
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     LLVM
+...

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,14 +4,14 @@
 ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
-# [Optional] Install CMake version different from what base image has already installed. 
+# [Optional] Install CMake version different from what base image has already installed.
 # CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
 
 # Optionally install the cmake for vcpkg
 COPY ./reinstall-cmake.sh /tmp/
 RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
-        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
     fi \
     && rm -f /tmp/reinstall-cmake.sh
 
@@ -19,5 +19,5 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
 # RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
 
 # [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends clang-tidy clang-format

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,26 +6,29 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
 		// Use Debian 11, Ubuntu 18.04 or Ubuntu 22.04 on local arm64/Apple Silicon
-		"args": { "VARIANT": "ubuntu-22.04" }
+		"args": {
+			"VARIANT": "ubuntu-22.04"
+		}
 	},
-	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
-
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.cpptools",
 		"ms-vscode.cmake-tools",
-		"formulahendry.code-runner"
+		"formulahendry.code-runner",
+		"xaver.clang-format",
+		"notskm.clang-tidy"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,6 @@
     "code-runner.executorMap": {
         "c": "make && ./$fileNameWithoutExt.out"
     },
-    "clang-tidy.checks": [
-        "clang-analyzer-*",
-        "readability-*",
-        "bugprone-*",
-        "misc-*",
-    ],
     "clang-tidy.compilerArgs": [
         "-std=c99",
         "-Wall",
@@ -19,7 +13,6 @@
     "[c]": {
         "editor.defaultFormatter": "xaver.clang-format"
     },
-    "clang-format.language.c.style": "LLVM",
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
     "files.associations": {

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ WDELOBJ = $(SRC:$(SRCDIR)/%$(EXT)=$(OBJDIR)\\%.o)
 ####################### Targets beginning here #########################
 ########################################################################
 
-all: lint $(APPNAME)
+all: $(APPNAME)
 
 # Builds the app
 $(APPNAME): $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ WDELOBJ = $(SRC:$(SRCDIR)/%$(EXT)=$(OBJDIR)\\%.o)
 ####################### Targets beginning here #########################
 ########################################################################
 
-all: $(APPNAME)
+all: lint $(APPNAME)
 
 # Builds the app
 $(APPNAME): $(OBJ)
@@ -45,6 +45,11 @@ $(APPNAME): $(OBJ)
 # Building rule for .o files and its .c/.cpp in combination with all .h
 $(OBJDIR)/%.o: $(SRCDIR)/%$(EXT)
 	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+######################## Run linter on C files #########################
+.PHONY: lint
+lint:
+	clang-tidy $(wildcard $(SRCDIR)/*$(EXT)) $(wildcard $(SRCDIR)/**/*$(EXT)) --
 
 ################### Cleaning rules for Unix-based OS ###################
 # Cleans complete project

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 Template repository for compiling, running and debugginc C/C++ on VS Code.
 
 [![Run on Repl.it](https://repl.it/badge/github/flych3r/template-c-cpp)](https://repl.it/github/flych3r/template-c-cpp)
+
+For the linting, the following packages are necessary: [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/) and [Clang Format](https://clang.llvm.org/docs/ClangFormat.html)
+
+If they are not installed in your machine, use the following command:
+
+```bash
+sudo apt install -y clang-tidy clang-format
+```

--- a/replit.nix
+++ b/replit.nix
@@ -3,6 +3,8 @@
 		pkgs.clang_12
 		pkgs.ccls
 		pkgs.gdb
-		pkgs.gnumake
+		pkgs.gnumake,
+		pkgs.clang-tidy,
+		pkgs.clang-format
 	];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -3,8 +3,7 @@
 		pkgs.clang_12
 		pkgs.ccls
 		pkgs.gdb
-		pkgs.gnumake,
-		pkgs.clang-tidy,
-		pkgs.clang-format
+		pkgs.gnumake
+		pkgs.clang-tools
 	];
 }


### PR DESCRIPTION
This allows using the linters from the makefile